### PR TITLE
Add user roles and allow access to regenerate access token page by own user or admin

### DIFF
--- a/Foundation.hs
+++ b/Foundation.hs
@@ -428,6 +428,7 @@ isAdmin = do
                   Nothing -> Unauthorized "You must be an admin to access this page"
                   Just _ -> Authorized
 
+-- | Access function to determine if a current user is the owner or has admin role.
 isOwnerOrAdmin :: Key User -> Handler AuthResult
 isOwnerOrAdmin uid = do
   mCurrentUid <- maybeAuthId

--- a/config/models
+++ b/config/models
@@ -5,6 +5,15 @@ User
     verified Bool
     UniqueUser ident
     deriving Typeable
+Role
+    name            Text
+    UniqueName      name
+    deriving        Show Generic
+UserRole
+    role            RoleId
+    user            UserId
+    UniqueRoleUser  role user
+    deriving        Show Generic
 Sale
     name            Text
     status          SaleStatus

--- a/test/Handler/RegenerateAccessTokenSpec.hs
+++ b/test/Handler/RegenerateAccessTokenSpec.hs
@@ -36,3 +36,41 @@ spec = withApp $ do
 
                       assertEq "Access token has changed" (mToken /= mTokenAfterChange) True
                   ) mUser
+
+        it "should user to access own regenerate access token page" $ do
+            userEntity <- createUser "alice"
+            let (Entity uid _) = userEntity
+            authenticateAs userEntity
+
+            get $ RegenerateAccessTokenR uid
+            statusIs 200
+
+        it "should not allow user to access another user's regenerate access token page" $ do
+            userEntity <- createUser "alice"
+            let (Entity uid _) = userEntity
+            authenticateAs userEntity
+
+            anotherUserEntity <- createUser "john"
+            authenticateAs anotherUserEntity
+
+            get $ RegenerateAccessTokenR uid
+            statusIs 403
+
+
+        it "should allow admin to access regenerate access token page on behalf of another user" $ do
+          -- Create "admin" role
+          roleId <- runDB . insert $ Role "admin"
+
+          -- Create users
+          userEntity <- createUser "alice"
+          let (Entity uid _) = userEntity
+
+          adminUserEntity <- createUser "john"
+          let (Entity adminUid _) = adminUserEntity
+
+          -- Make user an admin.
+          _ <- runDB . insert $ UserRole roleId adminUid
+          authenticateAs adminUserEntity
+
+          get $ RegenerateAccessTokenR uid
+          statusIs 200


### PR DESCRIPTION
#34

Add the notion of a `role` and allow users to have roles.

Now the Regenerate access token can be accessed by own user, or by an admin (e.g. access `http://localhost:3000/regenerate-access-token/4` by user ID 2 that is an `admin`)

![regenerate_access_token_and_circuit-yesod_ _amitai_amitais-macbook-pro_ _zsh_ _83x32](https://cloud.githubusercontent.com/assets/125707/25725530/15ac085c-3129-11e7-946f-1e89a0e6b96b.jpg)
